### PR TITLE
telebot minor bug fix

### DIFF
--- a/app/telegram/handlers/admin.py
+++ b/app/telegram/handlers/admin.py
@@ -1892,7 +1892,7 @@ def confirm_user_command(call: types.CallbackQuery):
         else:
             text = get_user_info_text(
                 status=user.status,
-                username=username,
+                username=user.username,
                 sub_url=user.subscription_url,
                 data_limit=user.data_limit,
                 usage=user.used_traffic,


### PR DESCRIPTION
The previous code caused an error due to the username variable not being properly referenced from the user object.
While creating a user in the bot, an error occurred stating 'Username already exists.' This issue is also documented here: https://github.com/Gozargah/Marzban/issues/1228